### PR TITLE
Add fetch cache, support Italian and skip missing order type

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -28,41 +28,48 @@ const csvHeaders = [
   "amount",
   "col1", // Not relevant column.
   "col2", // Not relevant column.
-  "orderId"];
+  "orderId",
+];
 
 // Read file contents of the CSV export.
 const csvFile = fs.readFileSync(inputFile, "utf-8");
 
 // Parse the CSV and convert to Ghostfolio import format.
-parse(csvFile, {
+parse(
+  csvFile,
+  {
     delimiter: ",",
     fromLine: 2,
     columns: csvHeaders,
     cast: (columnValue, context) => {
-
       // Custom mapping below.
 
       return columnValue;
-    }
-  }, async (_, records: DeGiroRecord[]) => {
-
+    },
+  },
+  async (_, records: DeGiroRecord[]) => {
     let errorExport = false;
 
     console.log(`Read CSV file ${inputFile}. Start processing..`);
     const exportFile: GhostfolioExport = {
       meta: {
         date: new Date(),
-        version: "v0"
+        version: "v0",
       },
-      activities: []
+      activities: [],
     };
 
     // Retrieve bearer token for authentication.
-    const bearerResponse = await fetch(`${process.env.GHOSTFOLIO_API_URL}/api/v1/auth/anonymous/${process.env.GHOSTFOLIO_SECRET}`);
+    const bearerResponse = await fetch(
+      `${process.env.GHOSTFOLIO_API_URL}/api/v1/auth/anonymous/${process.env.GHOSTFOLIO_SECRET}`
+    );
     const bearer = await bearerResponse.json();
 
     // Start progress bar.
-    const progress = new cliProgesss.SingleBar({}, cliProgesss.Presets.shades_classic);
+    const progress = new cliProgesss.SingleBar(
+      {},
+      cliProgesss.Presets.shades_classic
+    );
     progress.start(records.length - 1, 0);
 
     for (let idx = 0; idx < records.length; idx++) {
@@ -72,12 +79,14 @@ parse(csvFile, {
       const description = record.description.toLocaleLowerCase();
 
       // Skip some records which contains one of the words below.
-      if (description === "" ||
-          description.indexOf("ideal") > -1 ||
-          description.indexOf("flatex") > -1 ||
-          description.indexOf("cash sweep") > -1 ||
-          description.indexOf("withdrawal") > -1 ||
-          description.indexOf("pass-through") > -1) {
+      if (
+        description === "" ||
+        description.indexOf("ideal") > -1 ||
+        description.indexOf("flatex") > -1 ||
+        description.indexOf("cash sweep") > -1 ||
+        description.indexOf("withdrawal") > -1 ||
+        description.indexOf("pass-through") > -1
+      ) {
         continue;
       }
 
@@ -85,7 +94,11 @@ parse(csvFile, {
       // - The description does not contain the text 'dividend', and
       // - The description does not contain an '@' (present on buy/sell records), and
       // - The description does not contain an '/' (present on buy/sell fee records).
-      if (description.indexOf("dividend") === -1 && description.indexOf("\@") === -1 && description.indexOf("\/") === -1) {
+      if (
+        description.indexOf("dividend") === -1 &&
+        description.indexOf("@") === -1 &&
+        description.indexOf("/") === -1
+      ) {
         continue;
       }
 
@@ -96,7 +109,7 @@ parse(csvFile, {
       const tickerUrl = `${process.env.GHOSTFOLIO_API_URL}/api/v1/symbol/lookup?query=${record.isin}`;
       const tickerResponse = await fetch(tickerUrl, {
         method: "GET",
-        headers: [["Authorization", `Bearer ${bearer.authToken}`]]
+        headers: [["Authorization", `Bearer ${bearer.authToken}`]],
       });
 
       // Check if response was not unauthorized.
@@ -112,27 +125,27 @@ parse(csvFile, {
       let fees, unitPrice, numberShares;
       fees = unitPrice = numberShares = 0;
       let marker = "";
-     
+
       // Retrieve relevant data for a dividend record.
       if (description.indexOf("dividend") > -1) {
-
         // Retrieve the amount of the record. Check wether this is negative. If so, this is a dividend tax record.
-         // Dividend tax references to the previous record. This is always a "dividend" record.
+        // Dividend tax references to the previous record. This is always a "dividend" record.
         const amountRecord = parseFloat(record.amount.replace(",", "."));
         if (amountRecord < 0) {
-                    
-            // Retrieve the data from this record and place it on the previous processed record.
-            // This record should not be added, so it will be skipped after retrieving the required info.
+          // Retrieve the data from this record and place it on the previous processed record.
+          // This record should not be added, so it will be skipped after retrieving the required info.
 
-            // Get absolute dividend tax amount.
-            unitPrice = Math.abs(amountRecord);
+          // Get absolute dividend tax amount.
+          unitPrice = Math.abs(amountRecord);
 
-            // Set record values.
-            exportFile.activities[exportFile.activities.length - 1].fee = unitPrice;
-            exportFile.activities[exportFile.activities.length - 1].currency = record.currency;
-            exportFile.activities[exportFile.activities.length - 1].comment = "";
+          // Set record values.
+          exportFile.activities[exportFile.activities.length - 1].fee =
+            unitPrice;
+          exportFile.activities[exportFile.activities.length - 1].currency =
+            record.currency;
+          exportFile.activities[exportFile.activities.length - 1].comment = "";
 
-            continue;
+          continue;
         }
 
         // This is just a normal dividend record.
@@ -143,51 +156,67 @@ parse(csvFile, {
 
       // Check for a buy/sell record. This can be identified by an '@'.
       if (description.match(/\@/)) {
-        
         // Get the amount of shares from the description.
-        const numberSharesFromDescription = description.match(/([\d*\.?\,?\d*]+)/)[0];
+        const numberSharesFromDescription =
+          description.match(/([\d*\.?\,?\d*]+)/)[0];
         numberShares = parseFloat(numberSharesFromDescription);
 
-        // For buy/sale records, only the total amount is recorded. So the unit price needs to be calculated.        
+        // For buy/sale records, only the total amount is recorded. So the unit price needs to be calculated.
         const totalAmount = parseFloat(record.amount.replace(",", "."));
-        unitPrice = parseFloat((Math.abs(totalAmount) / numberShares).toFixed(3));
+        unitPrice = parseFloat(
+          (Math.abs(totalAmount) / numberShares).toFixed(3)
+        );
 
         // If amount is negative, so money has been removed, thus it's a buy record.
         if (totalAmount < 0) {
-
           orderType = GhostfolioOrderType.buy;
 
           // For a Buy record, the preceding record should be "txfees". This means the buy had a transaction fee associated.
-          if (exportFile.activities[exportFile.activities.length - 1].comment === "txfees") {
-
+          if (
+            exportFile.activities[exportFile.activities.length - 1].comment ===
+            "txfees"
+          ) {
             // Set the buy transaction data.
-            exportFile.activities[exportFile.activities.length - 1].type = orderType;
-            exportFile.activities[exportFile.activities.length - 1].symbol = tickers.items[0].symbol;
-            exportFile.activities[exportFile.activities.length - 1].quantity = numberShares;
-            exportFile.activities[exportFile.activities.length - 1].unitPrice = unitPrice;
-            exportFile.activities[exportFile.activities.length - 1].currency = record.currency;
-            exportFile.activities[exportFile.activities.length - 1].comment = "";
+            exportFile.activities[exportFile.activities.length - 1].type =
+              orderType;
+            exportFile.activities[exportFile.activities.length - 1].symbol =
+              tickers.items[0].symbol;
+            exportFile.activities[exportFile.activities.length - 1].quantity =
+              numberShares;
+            exportFile.activities[exportFile.activities.length - 1].unitPrice =
+              unitPrice;
+            exportFile.activities[exportFile.activities.length - 1].currency =
+              record.currency;
+            exportFile.activities[exportFile.activities.length - 1].comment =
+              "";
 
             continue;
           } else {
-
             // It is a buy transaction without fees (e.g. within Kernselectie).
             // This is only for support of older transactions before June 1st 2023, since the Kernselectie is no longer without fees.
             marker = "";
           }
         } else {
-            
-          // Amount is positive, so money is received, thus it's a sell record.                    
+          // Amount is positive, so money is received, thus it's a sell record.
           orderType = GhostfolioOrderType.sell;
 
           // For a Sale record, the preceding record should be "txfees". This means the sale had a transaction fee associated.
-          if (exportFile.activities[exportFile.activities.length - 1].comment === "txfees") {
-            exportFile.activities[exportFile.activities.length - 1].type = orderType;
-            exportFile.activities[exportFile.activities.length - 1].symbol = tickers.items[0].symbol;
-            exportFile.activities[exportFile.activities.length - 1].quantity = numberShares;
-            exportFile.activities[exportFile.activities.length - 1].unitPrice = unitPrice;
-            exportFile.activities[exportFile.activities.length - 1].currency = record.currency;
-            exportFile.activities[exportFile.activities.length - 1].comment = "";
+          if (
+            exportFile.activities[exportFile.activities.length - 1].comment ===
+            "txfees"
+          ) {
+            exportFile.activities[exportFile.activities.length - 1].type =
+              orderType;
+            exportFile.activities[exportFile.activities.length - 1].symbol =
+              tickers.items[0].symbol;
+            exportFile.activities[exportFile.activities.length - 1].quantity =
+              numberShares;
+            exportFile.activities[exportFile.activities.length - 1].unitPrice =
+              unitPrice;
+            exportFile.activities[exportFile.activities.length - 1].currency =
+              record.currency;
+            exportFile.activities[exportFile.activities.length - 1].comment =
+              "";
 
             continue;
           }
@@ -207,7 +236,10 @@ parse(csvFile, {
         continue;
       }
 
-      const date = dayjs(`${record.date} ${record.time}:00`, "DD-MM-YYYY HH:mm");
+      const date = dayjs(
+        `${record.date} ${record.time}:00`,
+        "DD-MM-YYYY HH:mm"
+      );
 
       // Add record to export.
       exportFile.activities.push({
@@ -220,7 +252,7 @@ parse(csvFile, {
         currency: record.currency,
         dataSource: "YAHOO",
         date: date.format("YYYY-MM-DDTHH:mm:ssZ"),
-        symbol: tickers.items.length > 0 ? tickers.items[0].symbol : ""
+        symbol: tickers.items.length > 0 ? tickers.items[0].symbol : "",
       });
     }
 
@@ -235,4 +267,5 @@ parse(csvFile, {
 
       console.log("Wrote data to 'ghostfolio-degiro.json'!");
     }
-});
+  }
+);

--- a/src/index.ts
+++ b/src/index.ts
@@ -272,6 +272,12 @@ parse(
     if (!errorExport) {
       console.log("Processing complete, writing to file..");
 
+      // Ghostfolio validation doesn't allow empty order types
+      exportFile.activities = exportFile.activities.filter((a) => {
+        if (!a.type) console.warn("Skipping activity (missing order type)", a);
+        return !!a.type;
+      });
+
       const result = JSON.stringify(exportFile);
       fs.writeFileSync("ghostfolio-degiro.json", result, { encoding: "utf-8" });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -226,7 +226,9 @@ parse(
       // When ISIN is given, check for transaction fees record.
       // For this record the "Amount" record should be retrieved. This contains the transaction fee in local currency.
       if (record.isin.length > 0) {
-        const creditMatch = description.match(/(en\/of)|(and\/or)|(und\/oder)/);
+        const creditMatch = description.match(
+          /(en\/of)|(and\/or)|(e\/o)|(und\/oder)/
+        );
         if (creditMatch) {
           fees = Math.abs(parseFloat(record.amount.replace(",", ".")));
           marker = "txfees";


### PR DESCRIPTION
I find your project very useful, while using it I made some changes you may be interested in:
- Apply Prettier: Feel free to rollback this one, I have it enabled by default in VS Code.
- Support Italian export when searching for fee description.
- The script is very slow when querying my local instance of Ghostfolio; I added a naive cache to speed up the ticker query.
- For some reason, in the export I used there were two subsequent fee entries, preventing the script to identify the respective buy/sell entry and leaving the fee entry without an order type. I was fine with just skipping it since it was a 0.01€ fee, feel free to remove this one if you think it doesn't fit the script logic.